### PR TITLE
Fixes typo error in watch mode example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ function build() {
             outfile: 'outfile.js',
             bundle: true,
         }))
-        .pipe(dist('./dist'))
+        .pipe(dest('./dist'))
 }
 
 function watchTask() {


### PR DESCRIPTION
Looks like there is typo error in "watch mode example".
Gulp method for destination is [`dest()`](https://gulpjs.com/docs/en/api/dest/), not `dist()`.
"build example" is OK.