### PR TITLE
metafileName should be optional as esbuild does not require it

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ type Options = Omit<
     BuildOptions,
     'write' | 'incremental' | 'entryPoints' | 'stdin' | 'watch'
 > & {
-	metafileName: string
+	metafileName?: string
 }
 
 interface CreateOptions {


### PR DESCRIPTION
The metafileName isn't required, and so I'm having to specify it as empty string for now, but the type definition shouldn't say its required.

Thanks for the gulp plugin! :)


