### PR TITLE
fix: Use loader configuration passed in plugin instead detection by file extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,13 +207,15 @@ function pipedBuild() {
 			}
 
 			for (const entry of entryPoints) {
+				const customLoader = esbuildOptions.loader && esbuildOptions.loader[entry.extname];
+				const loader = customLoader || entry.extname.slice(1);
 				const params = {
 					...commonParams,
 					outfile: entry.relative.replace(/\.(ts|tsx|jsx)$/, '.js'),
 					stdin: {
 						contents: entry.contents.toString(),
 						resolveDir: entry.dirname,
-						loader: entry.extname.slice(1),
+						loader,
 						sourcefile: entry.path,
 					},
 				}
@@ -269,13 +271,15 @@ function pipedAndIncrementalBuild() {
 			}
 
 			for (const entry of entryPoints) {
+				const customLoader = esbuildOptions.loader && esbuildOptions.loader[entry.extname];
+				const loader = customLoader || entry.extname.slice(1);
 				const params = {
 					...commonParams,
 					outfile: entry.relative.replace(/\.(ts|tsx|jsx)$/, '.js'),
 					stdin: {
 						contents: entry.contents.toString(),
 						resolveDir: entry.dirname,
-						loader: entry.extname.slice(1),
+						loader,
 						sourcefile: entry.path,
 					},
 				}

--- a/index.mjs
+++ b/index.mjs
@@ -211,13 +211,15 @@ function pipedBuild() {
 			}
 
 			for (const entry of entryPoints) {
+				const customLoader = esbuildOptions.loader && esbuildOptions.loader[entry.extname];
+				const loader = customLoader || entry.extname.slice(1);
 				const params = {
 					...commonParams,
 					outfile: entry.relative.replace(/\.(ts|tsx|jsx)$/, '.js'),
 					stdin: {
 						contents: entry.contents.toString(),
 						resolveDir: entry.dirname,
-						loader: entry.extname.slice(1),
+						loader,
 						sourcefile: entry.path,
 					},
 				}
@@ -273,13 +275,15 @@ function pipedAndIncrementalBuild() {
 			}
 
 			for (const entry of entryPoints) {
+				const customLoader = esbuildOptions.loader && esbuildOptions.loader[entry.extname];
+				const loader = customLoader || entry.extname.slice(1);
 				const params = {
 					...commonParams,
 					outfile: entry.relative.replace(/\.(ts|tsx|jsx)$/, '.js'),
 					stdin: {
 						contents: entry.contents.toString(),
 						resolveDir: entry.dirname,
-						loader: entry.extname.slice(1),
+						loader,
 						sourcefile: entry.path,
 					},
 				}


### PR DESCRIPTION
Example:
`src/SomeComponent/index.js` use JSX markup inside. But [`entry.extname.slice(1)`](https://github.com/ym-project/gulp-esbuild/blob/master/index.js#L216) detect loader as `js` which is not correct if `{loader: {'.js': 'jsx'} }` passed in plugin options.

The idea is to use overrides like in original esbuild with `loader` property.