### PR TITLE
fix(#16): fix esbuild interaction with gulp's virtual files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 A [gulp](https://gulpjs.com) plugin for the [esbuild](https://esbuild.github.io) bundler.
 
 There are two exports available: `gulpEsbuild` and `createGulpEsbuild`. In most cases you should use the `gulpEsbuild` export. Use the `createGuipEsbuild` export if you want to enable the esbuild's incremental build.
-The [esbuild's incremental build](https://esbuild.github.io/api/#incremental) is used with the [gulp's watching files API](https://gulpjs.com/docs/en/getting-started/watching-files/) and allows you to rebuild only changed parts of code ([example](https://github.com/ym-project/gulp-esbuild/tree/master/examples/watch));
+The [esbuild's incremental build](https://esbuild.github.io/api/#incremental) is used with the [gulp's watching files API](https://gulpjs.com/docs/en/getting-started/watching-files/) and allows you to rebuild only changed parts of code ([example](https://github.com/ym-project/gulp-esbuild/tree/v0/examples/watch));
 
 ```js
 const {createGulpEsbuild} = require('gulp-esbuild')
@@ -107,7 +107,7 @@ exports.watch = watchTask
 npm run watch
 ```
 
-More examples [here](https://github.com/ym-project/gulp-esbuild/tree/master/examples)
+More examples [here](https://github.com/ym-project/gulp-esbuild/tree/v0/examples)
 
 ## Plugin arguments
 

--- a/README.md
+++ b/README.md
@@ -3,19 +3,21 @@
 # gulp-esbuild
 A [gulp](https://gulpjs.com) plugin for the [esbuild](https://esbuild.github.io) bundler.
 
-There are two exports available: `gulpEsbuild` and `createGulpEsbuild`. In most cases you should use the `gulpEsbuild` export. Use the `createGuipEsbuild` export if you want to enable the esbuild's incremental build or piping:
-* the [esbuild's incremental build](https://esbuild.github.io/api/#incremental) is used with the [gulp's watching files API](https://gulpjs.com/docs/en/getting-started/watching-files/) and allows you to rebuild only changed parts of code ([example](https://github.com/ym-project/gulp-esbuild/tree/master/examples/watch));
-* piping allows you to receive data from other plugins via stream piping ([example](https://github.com/ym-project/gulp-esbuild/tree/master/examples/piping)).
+There are two exports available: `gulpEsbuild` and `createGulpEsbuild`. In most cases you should use the `gulpEsbuild` export. Use the `createGuipEsbuild` export if you want to enable the esbuild's incremental build.
+The [esbuild's incremental build](https://esbuild.github.io/api/#incremental) is used with the [gulp's watching files API](https://gulpjs.com/docs/en/getting-started/watching-files/) and allows you to rebuild only changed parts of code ([example](https://github.com/ym-project/gulp-esbuild/tree/master/examples/watch));
 
 ```js
 const {createGulpEsbuild} = require('gulp-esbuild')
 const gulpEsbuild = createGulpEsbuild({
 	incremental: true, // enables the esbuild's incremental build
-	piping: true,      // enables piping
 })
 ```
 
-**Notice**: `⚠️ piping is disabled by default ⚠️`
+### ⚠️ Notice ⚠️
+
+Esbuild doesn't fully support working with the virtual files which gulp send when you use: `src(...).pipe(gulpEsbuild(...))`.
+We found workaround using some tricks, but one limitation still remains. **Every file you send via `src(...)` must exist in the file system**.
+Its contents are not important, since they will be taken from the virtual file. But existence in the file system is required.
 
 ## Installation
 ```bash

--- a/examples/piping/gulpfile.js
+++ b/examples/piping/gulpfile.js
@@ -2,11 +2,8 @@ const {
 	src,
 	dest,
 } = require('gulp')
-const {createGulpEsbuild} = require('gulp-esbuild')
+const gulpEsbuild = require('gulp-esbuild')
 const gulpReplace = require('gulp-replace')
-const gulpEsbuild = createGulpEsbuild({
-	pipe: true,
-})
 
 function build() {
 	return src('./src/*.ts')

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,6 @@ declare namespace gulpEsbuild {
 
 	interface CreateOptions {
 		incremental?: boolean
-		pipe?: boolean
 	}
 	
 	type GulpEsbuild = (options: Options) => Transform

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const {build, context} = require('esbuild')
 const PluginError = require('plugin-error')
 const Vinyl = require('vinyl')
 const {name: PLUGIN_NAME} = require('./package.json')
+const resolvePlugin = require('./resolve-plugin')
 const metaFileDefaultName = 'metafile.json'
 
 //
@@ -32,48 +33,18 @@ function createTransformStream(flushFn, entryPoints) {
 	})
 }
 
-function omitPluginSpecialOptions(options) {
-	return omit(options, [
-		'metafileName',
-	])
-}
-
-function omit(object, keys = []) {
-	const obj = {}
-
-	for (const key in object) {
-		const value = object[key]
-
-		if (keys.includes(key)) {
-			continue
-		}
-
-		obj[key] = value
-	}
-
-	return obj
+function splitOptions(options) {
+	const {metafileName, ...esbuildOptions} = options
+	return {metafileName, esbuildOptions}
 }
 
 //
 // handlers
 //
 
-function createGulpEsbuild(createOptions = {}) {
-	const {
-		pipe,
-		incremental,
-	} = createOptions
-
+function createGulpEsbuild({incremental} = {}) {
 	if (incremental) {
-		if (pipe) {
-			return pipedAndIncrementalBuild()
-		}
-
 		return incrementalBuild()
-	}
-
-	if (pipe) {
-		return pipedBuild()
 	}
 
 	return simpleBuild()
@@ -81,11 +52,9 @@ function createGulpEsbuild(createOptions = {}) {
 
 function simpleBuild() {
 	return function plugin(pluginOptions = {}) {
+		/** @type Array<import('vinyl').BufferFile> */
 		const entryPoints = []
-		const esbuildOptions = omitPluginSpecialOptions(pluginOptions)
-		const specialOptions = {
-			metafileName: pluginOptions.metafileName,
-		}
+		const {metafileName, esbuildOptions} = splitOptions(pluginOptions)
 
 		async function flushFunction(cb) {
 			const params = {
@@ -93,6 +62,10 @@ function simpleBuild() {
 				...esbuildOptions,
 				entryPoints: entryPoints.map(entry => entry.path),
 				write: false,
+				plugins: [
+					resolvePlugin(entryPoints),
+					...(esbuildOptions.plugins || []),
+				],
 			}
 
 			// set outdir by default
@@ -116,7 +89,7 @@ function simpleBuild() {
 			})
 
 			if (result.metafile) {
-				const name = specialOptions.metafileName || metaFileDefaultName
+				const name = metafileName || metaFileDefaultName
 
 				this.push(createFile({
 					path: name,
@@ -135,11 +108,9 @@ function incrementalBuild() {
 	let ctx
 
 	return function plugin(pluginOptions = {}) {
+		/** @type Array<import('vinyl').BufferFile> */
 		const entryPoints = []
-		const esbuildOptions = omitPluginSpecialOptions(pluginOptions)
-		const specialOptions = {
-			metafileName: pluginOptions.metafileName,
-		}
+		const {metafileName, esbuildOptions} = splitOptions(pluginOptions)
 
 		async function flushFunction(cb) {
 			const params = {
@@ -147,6 +118,10 @@ function incrementalBuild() {
 				...esbuildOptions,
 				entryPoints: entryPoints.map(entry => entry.path),
 				write: false,
+				plugins: [
+					resolvePlugin(entryPoints),
+					...(esbuildOptions.plugins || []),
+				],
 			}
 
 			// set outdir by default
@@ -175,7 +150,7 @@ function incrementalBuild() {
 			})
 
 			if (result.metafile) {
-				const name = specialOptions.metafileName || metaFileDefaultName
+				const name = metafileName || metaFileDefaultName
 
 				this.push(createFile({
 					path: name,
@@ -189,141 +164,6 @@ function incrementalBuild() {
 		return createTransformStream(flushFunction, entryPoints)
 	}
 }
-
-function pipedBuild() {
-	return function plugin(pluginOptions = {}) {
-		const entryPoints = []
-		const esbuildOptions = omitPluginSpecialOptions(pluginOptions)
-		const specialOptions = {
-			metafileName: pluginOptions.metafileName,
-		}
-
-		async function flushFunction(cb) {
-			const commonParams = {
-				logLevel: 'silent',
-				...esbuildOptions,
-				write: false,
-			}
-
-			for (const entry of entryPoints) {
-				const customLoader = esbuildOptions.loader && esbuildOptions.loader[entry.extname]
-				const loader = customLoader || entry.extname.slice(1)
-				const outfile = esbuildOptions.outfile || entry.relative.replace(/\.(cts|mts|ts|tsx|jsx)$/, '.js')
-
-				const params = {
-					...commonParams,
-					outfile,
-					stdin: {
-						contents: entry.contents.toString(),
-						resolveDir: entry.dirname,
-						loader,
-						sourcefile: entry.path,
-					},
-				}
-
-				let result
-
-				try {
-					result = await build(params)
-				} catch(err) {
-					return cb(createError(err))
-				}
-
-				result.outputFiles.forEach(file => {
-					this.push(createFile({
-						path: file.path,
-						contents: Buffer.from(file.contents),
-					}))
-				})
-
-				if (result.metafile) {
-					const name = specialOptions.metafileName || metaFileDefaultName
-
-					this.push(createFile({
-						path: name,
-						contents: Buffer.from(JSON.stringify(result.metafile)),
-					}))
-				}
-
-			}
-
-			cb(null)
-		}
-
-		return createTransformStream(flushFunction, entryPoints)
-	}
-}
-
-function pipedAndIncrementalBuild() {
-	let ctx
-
-	return function plugin(pluginOptions = {}) {
-		const entryPoints = []
-		const esbuildOptions = omitPluginSpecialOptions(pluginOptions)
-		const specialOptions = {
-			metafileName: pluginOptions.metafileName,
-		}
-
-		async function flushFunction(cb) {
-			const commonParams = {
-				logLevel: 'silent',
-				...esbuildOptions,
-				write: false,
-			}
-
-			for (const entry of entryPoints) {
-				const customLoader = esbuildOptions.loader && esbuildOptions.loader[entry.extname]
-				const loader = customLoader || entry.extname.slice(1)
-				const outfile = esbuildOptions.outfile || entry.relative.replace(/\.(cts|mts|ts|tsx|jsx)$/, '.js')
-
-				const params = {
-					...commonParams,
-					outfile,
-					stdin: {
-						contents: entry.contents.toString(),
-						resolveDir: entry.dirname,
-						loader,
-						sourcefile: entry.path,
-					},
-				}
-
-				let result
-
-				try {
-					// if it's the first build
-					if (!ctx) {
-						ctx = await context(params)
-					}
-					
-					result = await ctx.rebuild()
-				} catch(err) {
-					return cb(createError(err))
-				}
-
-				result.outputFiles.forEach(file => {
-					this.push(createFile({
-						path: file.path,
-						contents: Buffer.from(file.contents),
-					}))
-				})
-
-				if (result.metafile) {
-					const name = specialOptions.metafileName || metaFileDefaultName
-
-					this.push(createFile({
-						path: name,
-						contents: Buffer.from(JSON.stringify(result.metafile)),
-					}))
-				}
-			}
-
-			cb(null)
-		}
-
-		return createTransformStream(flushFunction, entryPoints)
-	}
-}
-
 
 module.exports = createGulpEsbuild()
 module.exports.createGulpEsbuild = createGulpEsbuild

--- a/index.mjs
+++ b/index.mjs
@@ -3,7 +3,7 @@ import esbuild from 'esbuild'
 import PluginError from 'plugin-error'
 import Vinyl from 'vinyl'
 import {createRequire} from 'module'
-import resolvePlugin from './resolve-plugin'
+import resolvePlugin from './resolve-plugin.js'
 
 const require = createRequire(import.meta.url)
 const {name: PLUGIN_NAME} = require('./package.json')

--- a/index.mjs
+++ b/index.mjs
@@ -3,6 +3,7 @@ import esbuild from 'esbuild'
 import PluginError from 'plugin-error'
 import Vinyl from 'vinyl'
 import {createRequire} from 'module'
+import resolvePlugin from './resolve-plugin'
 
 const require = createRequire(import.meta.url)
 const {name: PLUGIN_NAME} = require('./package.json')
@@ -36,48 +37,18 @@ function createTransformStream(flushFn, entryPoints) {
 	})
 }
 
-function omitPluginSpecialOptions(options) {
-	return omit(options, [
-		'metafileName',
-	])
-}
-
-function omit(object, keys = []) {
-	const obj = {}
-
-	for (const key in object) {
-		const value = object[key]
-
-		if (keys.includes(key)) {
-			continue
-		}
-
-		obj[key] = value
-	}
-
-	return obj
+function splitOptions(options) {
+	const {metafileName, ...esbuildOptions} = options
+	return {metafileName, esbuildOptions}
 }
 
 //
 // handlers
 //
 
-function createGulpEsbuild(createOptions = {}) {
-	const {
-		pipe,
-		incremental,
-	} = createOptions
-
+function createGulpEsbuild({incremental} = {}) {
 	if (incremental) {
-		if (pipe) {
-			return pipedAndIncrementalBuild()
-		}
-
 		return incrementalBuild()
-	}
-
-	if (pipe) {
-		return pipedBuild()
 	}
 
 	return simpleBuild()
@@ -85,11 +56,9 @@ function createGulpEsbuild(createOptions = {}) {
 
 function simpleBuild() {
 	return function plugin(pluginOptions = {}) {
+		/** @type Array<import('vinyl').BufferFile> */
 		const entryPoints = []
-		const esbuildOptions = omitPluginSpecialOptions(pluginOptions)
-		const specialOptions = {
-			metafileName: pluginOptions.metafileName,
-		}
+		const {metafileName, esbuildOptions} = splitOptions(pluginOptions)
 
 		async function flushFunction(cb) {
 			const params = {
@@ -97,6 +66,10 @@ function simpleBuild() {
 				...esbuildOptions,
 				entryPoints: entryPoints.map(entry => entry.path),
 				write: false,
+				plugins: [
+					resolvePlugin(entryPoints),
+					...(esbuildOptions.plugins || []),
+				],
 			}
 
 			// set outdir by default
@@ -120,7 +93,7 @@ function simpleBuild() {
 			})
 
 			if (result.metafile) {
-				const name = specialOptions.metafileName || metaFileDefaultName
+				const name = metafileName || metaFileDefaultName
 
 				this.push(createFile({
 					path: name,
@@ -139,11 +112,9 @@ function incrementalBuild() {
 	let ctx
 
 	return function plugin(pluginOptions = {}) {
+		/** @type Array<import('vinyl').BufferFile> */
 		const entryPoints = []
-		const esbuildOptions = omitPluginSpecialOptions(pluginOptions)
-		const specialOptions = {
-			metafileName: pluginOptions.metafileName,
-		}
+		const {metafileName, esbuildOptions} = splitOptions(pluginOptions)
 
 		async function flushFunction(cb) {
 			const params = {
@@ -151,6 +122,10 @@ function incrementalBuild() {
 				...esbuildOptions,
 				entryPoints: entryPoints.map(entry => entry.path),
 				write: false,
+				plugins: [
+					resolvePlugin(entryPoints),
+					...(esbuildOptions.plugins || []),
+				],
 			}
 
 			// set outdir by default
@@ -179,148 +154,12 @@ function incrementalBuild() {
 			})
 
 			if (result.metafile) {
-				const name = specialOptions.metafileName || metaFileDefaultName
+				const name = metafileName || metaFileDefaultName
 
 				this.push(createFile({
 					path: name,
 					contents: Buffer.from(JSON.stringify(result.metafile)),
 				}))
-			}
-
-			cb(null)
-		}
-
-		return createTransformStream(flushFunction, entryPoints)
-	}
-}
-
-function pipedBuild() {
-	return function plugin(pluginOptions = {}) {
-		const entryPoints = []
-		const esbuildOptions = omitPluginSpecialOptions(pluginOptions)
-		const specialOptions = {
-			metafileName: pluginOptions.metafileName,
-		}
-
-		async function flushFunction(cb) {
-			const commonParams = {
-				logLevel: 'silent',
-				...esbuildOptions,
-				write: false,
-			}
-
-			for (const entry of entryPoints) {
-				const customLoader = esbuildOptions.loader && esbuildOptions.loader[entry.extname]
-				const loader = customLoader || entry.extname.slice(1)
-				const outfile = esbuildOptions.outfile || entry.relative.replace(/\.(cts|mts|ts|tsx|jsx)$/, '.js')
-
-				const params = {
-					...commonParams,
-					outfile,
-					stdin: {
-						contents: entry.contents.toString(),
-						resolveDir: entry.dirname,
-						loader,
-						sourcefile: entry.path,
-					},
-				}
-
-				let result
-
-				try {
-					result = await build(params)
-				} catch(err) {
-					return cb(createError(err))
-				}
-
-				result.outputFiles.forEach(file => {
-					this.push(createFile({
-						path: file.path,
-						contents: Buffer.from(file.contents),
-					}))
-				})
-
-				if (result.metafile) {
-					const name = specialOptions.metafileName || metaFileDefaultName
-
-					this.push(createFile({
-						path: name,
-						contents: Buffer.from(JSON.stringify(result.metafile)),
-					}))
-				}
-
-			}
-
-			cb(null)
-		}
-
-		return createTransformStream(flushFunction, entryPoints)
-	}
-}
-
-function pipedAndIncrementalBuild() {
-	let ctx
-
-	return function plugin(pluginOptions = {}) {
-		const entryPoints = []
-		const esbuildOptions = omitPluginSpecialOptions(pluginOptions)
-		const specialOptions = {
-			metafileName: pluginOptions.metafileName,
-		}
-
-		async function flushFunction(cb) {
-			const commonParams = {
-				logLevel: 'silent',
-				...esbuildOptions,
-				write: false,
-			}
-
-			for (const entry of entryPoints) {
-				const customLoader = esbuildOptions.loader && esbuildOptions.loader[entry.extname]
-				const loader = customLoader || entry.extname.slice(1)
-				const outfile = esbuildOptions.outfile || entry.relative.replace(/\.(cts|mts|ts|tsx|jsx)$/, '.js')
-
-				const params = {
-					...commonParams,
-					outfile,
-					stdin: {
-						contents: entry.contents.toString(),
-						resolveDir: entry.dirname,
-						loader,
-						sourcefile: entry.path,
-					},
-				}
-
-				let result
-
-				try {
-					// if it's the first build
-					if (!ctx) {
-						ctx = await context(params)
-					}
-					
-					result = await ctx.rebuild()
-				} catch(err) {
-					return cb(createError(err))
-				}
-
-				result.outputFiles.forEach(file => {
-					this.push(createFile({
-						path: file.path,
-						contents: Buffer.from(file.contents),
-					}))
-				})
-
-				if (result.metafile) {
-					const name = specialOptions.metafileName || metaFileDefaultName
-
-					this.push(createFile({
-						path: name,
-						contents: Buffer.from(JSON.stringify(result.metafile)),
-					}))
-				}
-
-				cb(null)
 			}
 
 			cb(null)

--- a/resolve-plugin.js
+++ b/resolve-plugin.js
@@ -1,50 +1,22 @@
-const fs = require('fs/promises')
-
 /**
  * @type {(files: Array<import('vinyl').BufferFile>) => import('esbuild').Plugin}
  * @argument files - gulp's virtual files
  */
-const resolvePlugin = (files) => ({
+const resolvePlugin = (virtualFiles) => ({
 	name: 'resolve-plugin',
 	setup(build) {
-		async function onResolve(path) {
-			const virtualFile = files.find((file) => file.path === path)
+		async function onLoad(path) {
+			const virtualFile = virtualFiles.find((file) => file.path === path)
 
-			// if there is no virtual file, read file content from file system
-			if (virtualFile === undefined) {
-				const contents = await fs.readFile(path, 'utf8')
+			if (virtualFile !== undefined) {
+				const contents = virtualFile.contents.toString()
 				return {contents}
 			}
 
-			// else read virtual file content
-			const contents = virtualFile.contents.toString()
-			return {contents}
+			return null
 		}
 
-		build.onResolve({filter: /.*/}, ({path, kind}) => {
-			// If there is no path in file system, esbuild throws error. To allow to pass virtual
-			// files we intercept default behavior and pass to onLoad function.
-
-			if (kind === 'entry-point') {
-				return {
-					path,
-					namespace: 'entryPointResolver',
-				}
-			}
-
-			return {
-				path,
-				external: true,
-			}
-		})
-
-		build.onLoad({filter: /.*/, namespace: 'entryPointResolver'}, ({path}) => {
-			return onResolve(path)
-		})
-
-		build.onLoad({filter: /.*/}, ({path}) => {
-			return onResolve(path)
-		})
+		build.onLoad({filter: /.*/}, ({path}) => onLoad(path))
 	},
 })
 

--- a/resolve-plugin.js
+++ b/resolve-plugin.js
@@ -1,46 +1,3 @@
-/** @type {(options: import('esbuild').BuildOptions) => import('esbuild').TransformOptions} */
-const prepareTransformOptions = (options) => {
-	const transformOptions = {...options}
-	const blackList = [
-		'bundle',
-		'splitting',
-		'preserveSymlinks',
-		'outfile',
-		'metafile',
-		'outdir',
-		'outbase',
-		'external',
-		'packages',
-		'alias',
-		'loader',
-		'resolveExtensions',
-		'mainFields',
-		'conditions',
-		'write',
-		'allowOverwrite',
-		'tsconfig',
-		'outExtension',
-		'publicPath',
-		'entryNames',
-		'chunkNames',
-		'assetNames',
-		'inject',
-		'entryPoints',
-		'stdin',
-		'plugins',
-		'absWorkingDir',
-		'nodePaths',
-	]
-
-	Object.keys(transformOptions).forEach((key) => {
-		if (blackList.includes(key)) {
-			delete transformOptions[key]
-		}
-	})
-
-	return transformOptions
-}
-
 /**
  * @type {(files: Array<import('vinyl').BufferFile>) => import('esbuild').Plugin}
  * @argument files - gulp's virtual files
@@ -55,18 +12,11 @@ const resolvePlugin = (virtualFiles) => ({
 				const fileContents = virtualFile.contents.toString()
 				const customLoader = build.initialOptions.loader && build.initialOptions.loader[virtualFile.extname]
 				const loader = customLoader || virtualFile.extname.slice(1)
-				const transformOptions = prepareTransformOptions(build.initialOptions)
-
-				const {code, warnings} = await build.esbuild.transform(fileContents, {
-					...transformOptions,
-					loader,
-				})
 
 				return {
-					contents: code,
-					warnings: warnings,
-					loader,
+					contents: fileContents,
 					resolveDir: virtualFile.dirname,
+					loader,
 				}
 			}
 

--- a/resolve-plugin.js
+++ b/resolve-plugin.js
@@ -1,3 +1,46 @@
+/** @type {(options: import('esbuild').BuildOptions) => import('esbuild').TransformOptions} */
+const prepareTransformOptions = (options) => {
+	const transformOptions = {...options}
+	const blackList = [
+		'bundle',
+		'splitting',
+		'preserveSymlinks',
+		'outfile',
+		'metafile',
+		'outdir',
+		'outbase',
+		'external',
+		'packages',
+		'alias',
+		'loader',
+		'resolveExtensions',
+		'mainFields',
+		'conditions',
+		'write',
+		'allowOverwrite',
+		'tsconfig',
+		'outExtension',
+		'publicPath',
+		'entryNames',
+		'chunkNames',
+		'assetNames',
+		'inject',
+		'entryPoints',
+		'stdin',
+		'plugins',
+		'absWorkingDir',
+		'nodePaths',
+	]
+
+	Object.keys(transformOptions).forEach((key) => {
+		if (blackList.includes(key)) {
+			delete transformOptions[key]
+		}
+	})
+
+	return transformOptions
+}
+
 /**
  * @type {(files: Array<import('vinyl').BufferFile>) => import('esbuild').Plugin}
  * @argument files - gulp's virtual files
@@ -9,8 +52,22 @@ const resolvePlugin = (virtualFiles) => ({
 			const virtualFile = virtualFiles.find((file) => file.path === path)
 
 			if (virtualFile !== undefined) {
-				const contents = virtualFile.contents.toString()
-				return {contents}
+				const fileContents = virtualFile.contents.toString()
+				const customLoader = build.initialOptions.loader && build.initialOptions.loader[virtualFile.extname]
+				const loader = customLoader || virtualFile.extname.slice(1)
+				const transformOptions = prepareTransformOptions(build.initialOptions)
+
+				const {code, warnings} = await build.esbuild.transform(fileContents, {
+					...transformOptions,
+					loader,
+				})
+
+				return {
+					contents: code,
+					warnings: warnings,
+					loader,
+					resolveDir: virtualFile.dirname,
+				}
 			}
 
 			return null

--- a/resolve-plugin.js
+++ b/resolve-plugin.js
@@ -7,7 +7,7 @@ const fs = require('fs/promises')
 const resolvePlugin = (files) => ({
 	name: 'resolve-plugin',
 	setup(build) {
-		build.onLoad({filter: /.*/}, async ({path}) => {
+		async function onResolve(path) {
 			const virtualFile = files.find((file) => file.path === path)
 
 			// if there is no virtual file, read file content from file system
@@ -19,6 +19,31 @@ const resolvePlugin = (files) => ({
 			// else read virtual file content
 			const contents = virtualFile.contents.toString()
 			return {contents}
+		}
+
+		build.onResolve({filter: /.*/}, ({path, kind}) => {
+			// If there is no path in file system, esbuild throws error. To allow to pass virtual
+			// files we intercept default behavior and pass to onLoad function.
+
+			if (kind === 'entry-point') {
+				return {
+					path,
+					namespace: 'entryPointResolver',
+				}
+			}
+
+			return {
+				path,
+				external: true,
+			}
+		})
+
+		build.onLoad({filter: /.*/, namespace: 'entryPointResolver'}, ({path}) => {
+			return onResolve(path)
+		})
+
+		build.onLoad({filter: /.*/}, ({path}) => {
+			return onResolve(path)
 		})
 	},
 })

--- a/resolve-plugin.js
+++ b/resolve-plugin.js
@@ -1,0 +1,26 @@
+const fs = require('fs/promises')
+
+/**
+ * @type {(files: Array<import('vinyl').BufferFile>) => import('esbuild').Plugin}
+ * @argument files - gulp's virtual files
+ */
+const resolvePlugin = (files) => ({
+	name: 'resolve-plugin',
+	setup(build) {
+		build.onLoad({filter: /.*/}, async ({path}) => {
+			const virtualFile = files.find((file) => file.path === path)
+
+			// if there is no virtual file, read file content from file system
+			if (virtualFile === undefined) {
+				const contents = await fs.readFile(path, 'utf8')
+				return {contents}
+			}
+
+			// else read virtual file content
+			const contents = virtualFile.contents.toString()
+			return {contents}
+		})
+	},
+})
+
+module.exports = resolvePlugin

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -26,119 +26,111 @@ function resolve(filePath) {
 // tests
 //
 
-// Notice!
-// Esbuild read files from file system by default. We can't pass contents or non-exist path via Vinyl.
-// So we set real path and empty contents fields.
-// new Vinyl({ path, contents })
-
-it('Got non-existent file. It should throw an error.', () => {
-	const stream = gulpEsbuild()
-
-	wrapStream(stream).catch(err => {
-		expect(err.message).toMatch('Could not resolve')
-	})
-
-	stream.write(new Vinyl({
-		path: resolve('not-existed.js'),
-		contents: Buffer.from(''),
-	}))
-
-	stream.end()
-})
-
-it('Got null. It should throw an error.', () => {
-	const stream = gulpEsbuild()
-
-	wrapStream(stream).catch(err => {
-		expect(err.message).toMatch('File should be a buffer')
-	})
-
-	stream.write(new Vinyl({
-		path: resolve('empty-file.js'),
-	}))
-
-	stream.end()
-})
-
-it('Got stream. It should throw an error.', () => {
-	const stream = gulpEsbuild()
-
-	wrapStream(stream).catch(err => {
-		expect(err.message).toMatch('File should be a buffer')
-	})
-
-	stream.write(new Vinyl({
-		path: resolve('empty-file.js'),
-		contents: new Readable(),
-	}))
-
-	stream.end()
-})
-
-it('Outdir should override default outdir', () => {
-	const stream = gulpEsbuild({
-		outdir: './subfolder',
-	})
-
-	wrapStream(stream).then(files => {
-		files.forEach(file => expect(file.path).toMatch('/subfolder/'))
-	})
-
-	stream.write(new Vinyl({
-		path: resolve('empty-file.js'),
-		contents: Buffer.from(''),
-	}))
-	stream.end()
-})
-
-it('Outfile should override default outdir', () => {
-	const stream = gulpEsbuild({
-		outfile: 'bundle.js',
-	})
-
-	// This plugin sets outdir option by default if user doesn't override it
-	// Outfile and outdir can not be used together so if there is no an error it's ok
-	wrapStream(stream).then(files => {
-		files.forEach(file => expect(file.path).not.toBeNull())
-	})
-
-	stream.write(new Vinyl({
-		path: resolve('empty-file.js'),
-		contents: Buffer.from(''),
-	}))
-	stream.end()
-})
-
-it('Entry files number should equal output files number', () => {
-	const stream = gulpEsbuild()
-
-	wrapStream(stream).then(files => {
-		expect(files.length).toBe(2)
-	})
-
-	stream.write(new Vinyl({
-		path: resolve('empty-file.js'),
-		contents: Buffer.from(''),
-	}))
-	stream.write(new Vinyl({
-		path: resolve('a.js'),
-		contents: Buffer.from(''),
-	}))
-
-	stream.end()
-})
-
 it('Check createGulpEsbuild export. Return function should equals gulpEsbuild function.', () => {
 	const fn = createGulpEsbuild()
 	expect(fn.name).toBe(gulpEsbuild.name)
 })
 
-// Notice!
-// Previously we wrote that we can't to pass contents via Vinyl because esbuild read files from file system.
-// Flag "pipe" changes a behavior. It use esbuild stdin API and esbuild can read files contents via Vinyl.
-// So we can pass any contents and path and it'll be ok.
+describe('Check file system files', () => {
+	it('Got non-existent file. It should throw an error.', () => {
+		const stream = gulpEsbuild()
+	
+		wrapStream(stream).catch(err => {
+			expect(err.message).toMatch('Could not resolve')
+		})
+	
+		stream.write(new Vinyl({
+			path: resolve('not-existed.js'),
+			contents: Buffer.from(''),
+		}))
+	
+		stream.end()
+	})
+	
+	it('Got null. It should throw an error.', () => {
+		const stream = gulpEsbuild()
+	
+		wrapStream(stream).catch(err => {
+			expect(err.message).toMatch('File should be a buffer')
+		})
+	
+		stream.write(new Vinyl({
+			path: resolve('empty-file.js'),
+		}))
+	
+		stream.end()
+	})
+	
+	it('Got stream. It should throw an error.', () => {
+		const stream = gulpEsbuild()
+	
+		wrapStream(stream).catch(err => {
+			expect(err.message).toMatch('File should be a buffer')
+		})
+	
+		stream.write(new Vinyl({
+			path: resolve('empty-file.js'),
+			contents: new Readable(),
+		}))
+	
+		stream.end()
+	})
+	
+	it('Outdir should override default outdir', () => {
+		const stream = gulpEsbuild({
+			outdir: './subfolder',
+		})
+	
+		wrapStream(stream).then(files => {
+			files.forEach(file => expect(file.path).toMatch('/subfolder/'))
+		})
+	
+		stream.write(new Vinyl({
+			path: resolve('empty-file.js'),
+			contents: Buffer.from(''),
+		}))
+		stream.end()
+	})
+	
+	it('Outfile should override default outdir', () => {
+		const stream = gulpEsbuild({
+			outfile: 'bundle.js',
+		})
+	
+		// This plugin sets outdir option by default if user doesn't override it
+		// Outfile and outdir can not be used together so if there is no an error it's ok
+		wrapStream(stream).then(files => {
+			files.forEach(file => expect(file.path).not.toBeNull())
+		})
+	
+		stream.write(new Vinyl({
+			path: resolve('empty-file.js'),
+			contents: Buffer.from(''),
+		}))
+		stream.end()
+	})
+	
+	it('Entry files number should equal output files number', () => {
+		const stream = gulpEsbuild()
+	
+		wrapStream(stream).then(files => {
+			expect(files.length).toBe(2)
+		})
+	
+		stream.write(new Vinyl({
+			path: resolve('empty-file.js'),
+			contents: Buffer.from(''),
+		}))
+		stream.write(new Vinyl({
+			path: resolve('a.js'),
+			contents: Buffer.from(''),
+		}))
+	
+		stream.end()
+	})
+})
 
-describe('Check pipe flag', () => {
+describe('Check virtual files', () => {
 	it('Passed contents should pass to plugin.', () => {
 		const fn = createGulpEsbuild({pipe: true})
 		const stream = fn()
@@ -189,7 +181,7 @@ describe('Check pipe flag', () => {
 		})
 
 		stream.write(new Vinyl({
-			path: resolve('empty-file.ts'),
+			path: resolve('empty-file.js'),
 			contents: Buffer.from(''),
 			base: resolve(''),
 		}))
@@ -198,63 +190,41 @@ describe('Check pipe flag', () => {
 	})
 })
 
-it.todo('Check incremental flag.')
-it.todo('Check incremental and pipe flags together.')
-
-it('Check metafile.', async () => {
-	const stream = gulpEsbuild({
-		metafile: true,
+describe('Check metafile', () => {
+	it('Generate metafile.', async () => {
+		const stream = gulpEsbuild({
+			metafile: true,
+		})
+	
+		wrapStream(stream).then(files => {
+			expect(files.length).toBe(2)
+			expect(files[1].path).toBe('metafile.json')
+		})
+	
+		stream.write(new Vinyl({
+			path: resolve('empty-file.js'),
+			contents: Buffer.from(''),
+		}))
+	
+		stream.end()
 	})
-
-	wrapStream(stream).then(files => {
-		expect(files.length).toBe(2)
-		expect(files[1].path).toBe('metafile.json')
+	
+	it('Set custom name.', async () => {
+		const stream = gulpEsbuild({
+			metafile: true,
+			metafileName: 'meta.json',
+		})
+	
+		wrapStream(stream).then(files => {
+			expect(files.length).toBe(2)
+			expect(files[1].path).toBe('meta.json')
+		})
+	
+		stream.write(new Vinyl({
+			path: resolve('empty-file.js'),
+			contents: Buffer.from(''),
+		}))
+	
+		stream.end()
 	})
-
-	stream.write(new Vinyl({
-		path: resolve('empty-file.js'),
-		contents: Buffer.from(''),
-	}))
-
-	stream.end()
-})
-
-it('Check metafile. Set metafileName.', async () => {
-	const stream = gulpEsbuild({
-		metafile: true,
-		metafileName: 'meta.json',
-	})
-
-	wrapStream(stream).then(files => {
-		expect(files.length).toBe(2)
-		expect(files[1].path).toBe('meta.json')
-	})
-
-	stream.write(new Vinyl({
-		path: resolve('empty-file.js'),
-		contents: Buffer.from(''),
-	}))
-
-	stream.end()
-})
-
-it('Check metafile. With pipe flag.', async () => {
-	const fn = createGulpEsbuild({pipe: true})
-	const stream = fn({
-		metafile: true,
-		metafileName: 'meta.json',
-	})
-
-	wrapStream(stream).then(files => {
-		expect(files.length).toBe(2)
-		expect(files[1].path).toBe('meta.json')
-	})
-
-	stream.write(new Vinyl({
-		path: resolve('empty-file.js'),
-		contents: Buffer.from(''),
-		base: resolve(''),
-	}))
-
-	stream.end()
 })

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -35,8 +35,8 @@ describe('Check file system files', () => {
 	it('Got non-existent file. It should throw an error.', () => {
 		const stream = gulpEsbuild()
 
-		wrapStream(stream).then(files => {
-			files.forEach(file => expect(file.path).toMatch('not-existed.js'))
+		wrapStream(stream).catch(err => {
+			expect(err.message).toMatch('Could not resolve')
 		})
 	
 		stream.write(new Vinyl({

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -143,7 +143,6 @@ describe('Check virtual files', () => {
 		stream.write(new Vinyl({
 			path: resolve('empty-file.js'),
 			contents: Buffer.from(content),
-			base: resolve(''),
 		}))
 	
 		stream.end()
@@ -162,7 +161,6 @@ describe('Check virtual files', () => {
 		stream.write(new Vinyl({
 			path: resolve('empty-file.js'),
 			contents: Buffer.from(content),
-			base: resolve(''),
 		}))
 
 		stream.end()
@@ -179,7 +177,56 @@ describe('Check virtual files', () => {
 		stream.write(new Vinyl({
 			path: resolve('empty-file.js'),
 			contents: Buffer.from(''),
-			base: resolve(''),
+		}))
+
+		stream.end()
+	})
+
+	it('Check typescript loader', () => {
+		const stream = gulpEsbuild({
+			loader: {
+				'.ts': 'ts',
+			},
+		})
+		const content = `
+			const n: number = 10;
+		`
+		const expectContent = 'const n = 10;'
+
+		wrapStream(stream).then(files => {
+			const [file] = files
+			expect(file.contents.toString()).toContain(expectContent)
+		})
+
+		stream.write(new Vinyl({
+			path: resolve('empty-file.ts'),
+			contents: Buffer.from(content),
+		}))
+
+		stream.end()
+	})
+
+	it('Check any import and file generation', () => {
+		const stream = gulpEsbuild({
+			loader: {
+				'.css': 'css',
+			},
+			bundle: true,
+		})
+		const content = `
+			import './styles.css';
+			console.log('hello');
+		`
+		
+		wrapStream(stream).then(files => {
+			const [jsFile, cssFile] = files
+			expect(jsFile.path.endsWith('.js')).toBeTruthy()
+			expect(cssFile.path.endsWith('.css')).toBeTruthy()
+		})
+
+		stream.write(new Vinyl({
+			path: resolve('empty-file.js'),
+			contents: Buffer.from(content),
 		}))
 
 		stream.end()

--- a/test/e2e.test.js
+++ b/test/e2e.test.js
@@ -34,9 +34,9 @@ it('Check createGulpEsbuild export. Return function should equals gulpEsbuild fu
 describe('Check file system files', () => {
 	it('Got non-existent file. It should throw an error.', () => {
 		const stream = gulpEsbuild()
-	
-		wrapStream(stream).catch(err => {
-			expect(err.message).toMatch('Could not resolve')
+
+		wrapStream(stream).then(files => {
+			files.forEach(file => expect(file.path).toMatch('not-existed.js'))
 		})
 	
 		stream.write(new Vinyl({
@@ -132,8 +132,7 @@ describe('Check file system files', () => {
 
 describe('Check virtual files', () => {
 	it('Passed contents should pass to plugin.', () => {
-		const fn = createGulpEsbuild({pipe: true})
-		const stream = fn()
+		const stream = gulpEsbuild()
 		const content = 'console.log("custom content inside empty-file.js")'
 	
 		wrapStream(stream).then(files => {
@@ -152,9 +151,7 @@ describe('Check virtual files', () => {
 
 	it ('Pass "outfile" option. Outfile name should be the same', () => {
 		const outfile = 'result.jsx'
-
-		const fn = createGulpEsbuild({pipe: true})
-		const stream = fn({outfile})
+		const stream = gulpEsbuild({outfile})
 		const content = 'console.log("")'
 
 		wrapStream(stream).then(files => {
@@ -172,8 +169,7 @@ describe('Check virtual files', () => {
 	})
 
 	it('Do not pass "outfile" option. Outfile name should have .js extension', () => {
-		const fn = createGulpEsbuild({pipe: true})
-		const stream = fn()
+		const stream = gulpEsbuild()
 		
 		wrapStream(stream).then(files => {
 			const [file] = files

--- a/test/fixtures/styles.css
+++ b/test/fixtures/styles.css
@@ -1,0 +1,3 @@
+body {
+	margin: 0;
+}


### PR DESCRIPTION
Changes:
- remove `pipe` flag. Now plugin works with both file system files and virtual files by default
- update examples
- update docs
- simplify source code